### PR TITLE
Update lightrag web UI logo

### DIFF
--- a/lightrag_webui/src/App.tsx
+++ b/lightrag_webui/src/App.tsx
@@ -169,7 +169,7 @@ function App() {
               <div className="min-w-[200px] w-auto flex items-center">
                 <a href={webuiPrefix} className="flex items-center gap-2">
                   <img
-                    src="https://ae7an1f5d2ydi587.public.blob.vercel-storage.com/Augentik/agentic%20logo.png"
+                    src="https://ae7an1f5d2ydi587.public.blob.vercel-storage.com/Augentik/Augentik%20Logo.png"
                     alt="Augentik Logo"
                     className="h-7 w-7 object-contain mr-2"
                     style={{ display: 'inline-block', verticalAlign: 'middle' }}

--- a/lightrag_webui/src/components/ui/sign-in.tsx
+++ b/lightrag_webui/src/components/ui/sign-in.tsx
@@ -73,7 +73,7 @@ export const SignInPage: React.FC<SignInPageProps> = ({
           <div className="flex flex-col gap-6">
             {/* Augentik Logo */}
             <img
-              src="https://ae7an1f5d2ydi587.public.blob.vercel-storage.com/Augentik/agentic%20logo.png"
+              src="https://ae7an1f5d2ydi587.public.blob.vercel-storage.com/Augentik/Augentik%20Logo.png"
               alt="Augentik Logo"
               className="mx-auto mb-2 w-32 h-32 object-contain"
             />

--- a/lightrag_webui/src/features/LandingPage.tsx
+++ b/lightrag_webui/src/features/LandingPage.tsx
@@ -10,7 +10,7 @@ import { Home, User, Layers, LogIn } from "lucide-react"
 import SectionWithMockup from "@/components/ui/section-with-mockup"
 
 const splineUrl = 'https://ae7an1f5d2ydi587.public.blob.vercel-storage.com/Augentik/Augentik%20Spline.spline';
-const logoUrl = 'https://ae7an1f5d2ydi587.public.blob.vercel-storage.com/Augentik/agentic%20logo.png';
+const logoUrl = 'https://ae7an1f5d2ydi587.public.blob.vercel-storage.com/Augentik/Augentik%20Logo.png';
 
 const INTEGRATION_LOGOS = [
   { src: 'https://ae7an1f5d2ydi587.public.blob.vercel-storage.com/Augentik/svg%20logos/azure.svg', alt: 'Azure' },


### PR DESCRIPTION
## Summary
- replace old Agentic logo with Augentik logo across the web UI

## Testing
- `npm run lint` *(fails: cannot find `@eslint/js`)*
- `pytest -q` *(fails: missing `numpy`, `requests`)*

------
https://chatgpt.com/codex/tasks/task_e_687b820daf3c832f9914ae133b2daee2